### PR TITLE
chore: ignore gradle wrapper jar and document regeneration

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,17 @@ lib/
 2. Proporciona token y endpoint desde el panel de ajustes dentro de la aplicación.
 3. Opcionalmente configura la frase de activación, frase de terminación y voz preferida.
 
+### Android
+
+Tras clonar el repositorio, ejecuta el siguiente comando dentro de la carpeta `android/` para regenerar el Gradle Wrapper de forma local:
+
+```bash
+cd android
+gradle wrapper
+```
+
+Esto descargará el `gradle-wrapper.jar` necesario para los comandos de `gradlew` sin añadir el binario al control de versiones.
+
 ## Ejecución
 
 ```bash

--- a/android/.gitignore
+++ b/android/.gitignore
@@ -6,3 +6,4 @@
 /build/
 /captures/
 .cxx/
+gradle/wrapper/gradle-wrapper.jar


### PR DESCRIPTION
## Summary
- add the Gradle wrapper jar to the Android .gitignore to keep the binary out of version control
- document the need to regenerate the wrapper locally after cloning the project

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e00672b6e08333ac61ed69aad75be3