### PR TITLE
Use Flutter-supported Kotlin plugin version

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id "com.android.application" version "8.7.2" apply false
-    id "org.jetbrains.kotlin.android" version "2.0.21" apply false
+    id "org.jetbrains.kotlin.android" version "1.9.24" apply false
     id "com.android.application" version "8.1.2" apply false
     id "org.jetbrains.kotlin.android" version "1.9.10" apply false
 }


### PR DESCRIPTION
## Summary
- update the Android Kotlin plugin version to 1.9.24 to match Flutter-supported tooling

## Testing
- ⚠️ flutter pub get *(fails: `flutter` command not found in container)*
- ⚠️ flutter run *(fails: `flutter` command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e02973aa188333ab47eff049ebe3e3