### PR TITLE
Fix duplicate Android plugin declarations in build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,8 +1,6 @@
 plugins {
     id "com.android.application" version "8.7.2" apply false
     id "org.jetbrains.kotlin.android" version "1.9.24" apply false
-    id "com.android.application" version "8.1.2" apply false
-    id "org.jetbrains.kotlin.android" version "1.9.24" apply false
 }
 
 allprojects {


### PR DESCRIPTION
## Summary
- remove the duplicate Android application and Kotlin plugin lines from `android/build.gradle`

## Testing
- flutter build apk *(fails: `flutter` command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e02e9b856483338ff83cbcf7c9a9a3